### PR TITLE
👆🏽🤓

### DIFF
--- a/.github/workflows/random-image.yml
+++ b/.github/workflows/random-image.yml
@@ -2,7 +2,7 @@ name: Random Profile Image
 
 on:
   schedule:
-    - cron: '*/10 * * * *' # Runs every 10 minutes for testing
+    - cron: '0 8 * * * *' # Runs everyday at 08.00
   workflow_dispatch:  # Allows manual triggering
 
 jobs:

--- a/.github/workflows/random-image.yml
+++ b/.github/workflows/random-image.yml
@@ -2,7 +2,7 @@ name: Random Profile Image
 
 on:
   schedule:
-    - cron: "*/10 * * * *"  # Runs every 10 minutes for testing
+    - cron: '*/10 * * * *' # Runs every 10 minutes for testing
   workflow_dispatch:  # Allows manual triggering
 
 jobs:

--- a/.github/workflows/random-image.yml
+++ b/.github/workflows/random-image.yml
@@ -2,7 +2,7 @@ name: Random Profile Image
 
 on:
   schedule:
-    - cron: '0 8 * * * *' # Runs everyday at 08.00
+    - cron: '0 8 * * *' # Runs everyday at 08.00
   workflow_dispatch:  # Allows manual triggering
 
 jobs:


### PR DESCRIPTION
In GitHub Actions workflow files (YAML format), the cron expression should be enclosed in single quotes ('). This is because the asterisk (*) and other special characters in cron expressions have special meanings in YAML, so using single quotes ensures they're interpreted correctly.

For example, a workflow that runs every 10 minutes would look like this:


```YAML
on:
  schedule:
    - cron: '*/10 * * * *'
```
The single quotes around the cron expression are important. If you don't include them, the YAML parser might interpret the asterisks as special YAML syntax rather than as part of your cron expression, which could cause your workflow to fail or behave unexpectedly.